### PR TITLE
Fix hmctl conflicts and nodemask cleanup

### DIFF
--- a/hmalloc/src/hmalloc.c
+++ b/hmalloc/src/hmalloc.c
@@ -73,6 +73,8 @@ void update_env(void) {
     use_jemalloc = getenv_jemalloc();
     nodemask = getenv_nodemask();
     mpol_mode = getenv_mpol_mode();
+    if (nodemask > 0)
+        maxnode = numa_max_node() + 2;
 }
 
 __attribute__((constructor)) void hmalloc_init(void) {
@@ -97,7 +99,7 @@ void *hmalloc(size_t size) {
         return malloc(size);
 
     ptr = mallocx(size, MALLOCX_ARENA(arena_index) | MALLOCX_TCACHE_NONE);
-    if (errno == ENOMEM)
+    if (ptr == NULL)
         return NULL;
     return ptr;
 }
@@ -113,10 +115,16 @@ void hfree(void *ptr) {
 }
 
 void *hcalloc(size_t nmemb, size_t size) {
-    void *ptr = hmalloc(nmemb * size);
+    size_t total;
+    if (nmemb && size > SIZE_MAX / nmemb) {
+        errno = ENOMEM;
+        return NULL;
+    }
+    total = nmemb * size;
+    void *ptr = hmalloc(total);
 
     if (likely(ptr))
-        memset(ptr, 0, nmemb * size);
+        memset(ptr, 0, total);
     return ptr;
 }
 

--- a/hmalloc/src/hmctl.c
+++ b/hmalloc/src/hmctl.c
@@ -70,19 +70,19 @@ static error_t parse_option(int key, char *arg, struct argp_state *state) {
     switch (key) {
     case 'm':
         opts->membind = arg;
-        if (opts->preferred > 0)
+        if (opts->preferred >= 0 || opts->preferred_many)
             fail_mpol_conflict(state, key);
         break;
 
     case 'P':
         opts->preferred_many = arg;
-        if (opts->membind)
+        if (opts->membind || opts->preferred >= 0)
             fail_mpol_conflict(state, key);
         break;
 
     case 'p':
         opts->preferred = atoi(arg);
-        if (opts->membind)
+        if (opts->membind || opts->preferred_many)
             fail_mpol_conflict(state, key);
         break;
 
@@ -134,6 +134,7 @@ static void setup_child_environ(struct opts *opts) {
         if (bm) {
             snprintf(buf, sizeof(buf), "%lu", *bm->maskp);
             setenv("HMALLOC_NODEMASK", buf, 1);
+            numa_free_nodemask(bm);
         }
     } else if (opts->preferred_many) {
         snprintf(buf, sizeof(buf), "%d", MPOL_PREFERRED_MANY);
@@ -143,6 +144,7 @@ static void setup_child_environ(struct opts *opts) {
         if (bm) {
             snprintf(buf, sizeof(buf), "%lu", *bm->maskp);
             setenv("HMALLOC_NODEMASK", buf, 1);
+            numa_free_nodemask(bm);
         }
     } else if (opts->preferred >= 0) {
         /* ignore when --membind is used */
@@ -160,6 +162,7 @@ static void setup_child_environ(struct opts *opts) {
         if (bm) {
             snprintf(buf, sizeof(buf), "%lu", *bm->maskp);
             setenv("HMALLOC_NODEMASK", buf, 1);
+            numa_free_nodemask(bm);
         }
     } else if (opts->interleave) {
         snprintf(buf, sizeof(buf), "%d", MPOL_INTERLEAVE);
@@ -169,6 +172,7 @@ static void setup_child_environ(struct opts *opts) {
         if (bm) {
             snprintf(buf, sizeof(buf), "%lu", *bm->maskp);
             setenv("HMALLOC_NODEMASK", buf, 1);
+            numa_free_nodemask(bm);
         }
     }
 


### PR DESCRIPTION
## Summary
- ensure hmctl options conflict when `--preferred` mixes with other policies
- free nodemask bitmasks in hmctl
- rely on mallocx return value instead of errno

## Testing
- `cmake ../hmalloc -DHMALLOC_TEST=OFF` *(fails: jemalloc library not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a68b9cee88321a750a5b77677e927